### PR TITLE
[iOS Fix] Set meta theme color to match navbar background

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 	<meta charset="UTF-8">
 	<meta name="description" content="Treasure Hacks is a recurring hackathon dedicated to creating a place where high-school students throughout the nation can build computer science communities.">
 	<title>Treasure Hacks High School Hackathon</title>
+  <meta name="theme-color" content="#111">
 	<link rel="icon" href="logos/image5.png">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>

--- a/schedule.html
+++ b/schedule.html
@@ -5,6 +5,7 @@
 		<meta charset="UTF-8">
 		<meta name="description" content="Treasure Hacks is a recurring hackathon hosted by students at Tesoro High School.">
 		<title>Schedule - TreasureHacks Hackathon</title>
+    <meta name="theme-color" content="#111">
 		<link rel="icon" href="logos/image5.png">
     <meta name="viewport" content="width=device-width,initial-scale=1">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/team.html
+++ b/team.html
@@ -5,6 +5,7 @@
 		<meta charset="UTF-8">
 		<meta name="description" content="Treasure Hacks is a recurring hackathon hosted by students at Tesoro High School.">
 		<title>Team - TreasureHacks Hackathon</title>
+    <meta name="theme-color" content="#111">
 		<link rel="icon" href="logos/image5.png">
     <meta name="viewport" content="width=device-width,initial-scale=1">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/54484616/134775140-7b70e099-c253-4605-805b-deeb6786636b.png)

After:
![image](https://user-images.githubusercontent.com/54484616/134775116-940d6a94-9d89-43cd-aad5-47d4f3628172.png)
(unfortunately doesn't support transparency, so it can't be exact)