### PR TITLE
Fix width bug on safari

### DIFF
--- a/views/previous/past-events.scss
+++ b/views/previous/past-events.scss
@@ -39,7 +39,9 @@ div.sponsor-grid {
   display: grid;
   width: 100%;
   grid-auto-flow: row;
-  grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+  @media (min-width: 550px) {
+    grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+  }
   gap: 40px;
   padding: 0 40px;
 


### PR DESCRIPTION
Past event pages for Treasure Hacks 3.5 and 3.0 should no longer scroll sideways on iPhone Safari.